### PR TITLE
Delete icons since corrupted

### DIFF
--- a/icons/raised-both.png
+++ b/icons/raised-both.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:053890b39d00c64239d2c5255c456a9926454755bf114d62736e28c4b9eb776c
-size 19894

--- a/icons/raised-left.png
+++ b/icons/raised-left.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d51c4ac10463e95933a8b0498a32bab41c9d721673dac986b461413bbc1a21b6
-size 7954

--- a/icons/raised-right.png
+++ b/icons/raised-right.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7e8baa7c2570ecec210a2784ed1f3bddbe5712da16577c02a79f3d60afc9f04
-size 8015


### PR DESCRIPTION
We added icons before they were properly tracked in Git LFS.